### PR TITLE
Updates since last meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,42 @@ JSON object in the form:
 }
 ```
 
+## POST - /deregister_file_by_hash
+Removes you as a host for the specified file.
+Requires a guid.
+If a file has no hosts remaining, removes it.
+
+### Input
+DELETE request to the endpoint url with a JSON object.
+
+Ex: `localhost:42069/keep_alive`
+
+JSON object in the form:
+```python
+{
+    "file_hash": <files full hash>,   #integer
+    "guid": "<client's guid>",   #string
+    "seq_number": <clients current sequence number/sequence number of this message> #integer
+}
+```
+
+### Output
+JSON object in the form:
+```python
+{
+    "success": true   #boolean
+}
+```
+
+### On Error
+JSON object in the form:
+```python
+{
+    "success": false,   #boolean
+    "error": "<error reason>"   #string
+}
+```
+
 ## UPDATE - /tracker_sync
 Send/receive an information update to/from another tracker.
 If the tracker has seen the event already, it ignores it. If the tracker has not seen the

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Currently uses port `42069` by default, but will use the port specified in the c
 * PUT - /keep_alive
 * DELETE - /deregister_file
 
-## GET - /list_files
+## GET - /file_list
 Gets the list of files that the tracker knows about.
 
 ### Input
 GET request to the endpoint url.
 
-Ex: `localhost:42069/list_files`
+Ex: `localhost:42069/file_list`
 
 ### Output
 JSON object in the form:

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ By default the tracker will load setting from `config.toml`.
 Currently uses port `42069` by default, but will use the port specified in the config file.
 
 ## Endpoints
-* GET - /list_files
+* GET - /file_list
 * GET - /file/<file_id>
+* GET - /file_by_hash/<file_full_hash>
 * GET - /tracker_list
 * POST - /add_file
 * PUT - /keep_alive
@@ -87,6 +88,49 @@ Gets the information about a specified file, including peers hosting it and its 
 GET request to the endpoint url, containing the file's id in the url.
 
 Ex: `localhost:42069/file/2`
+
+### Output
+JSON object in the form:
+```python
+{
+    "success": true,    #boolean
+    "name": "<file name>", #string
+    "file_hash": "<hash of the full file>",    #string (sha256 hash)
+    "peers": [
+        {
+            "ip": "<peer's ip>" #string 
+        },
+        ...
+    ],
+    "chunks": [
+        {
+            "id": <chunk id for sequencing>,    #integer
+            "name": "<chunk filename>", #string
+            "hash": "<hash of chunk>"   #string (sha256 hash)
+        },
+        ...
+    ]
+}
+```
+
+### On Error
+JSON object in the form:
+```python
+{
+    "success": false,   #boolean
+    "error": "<error reason>"   #string
+}
+```
+
+## GET - /file_by_hash/<file_full_hash>
+Gets the information about a specified file, including peers hosting it and its chunks.
+
+### Input
+GET request to the endpoint url, containing the file's full hash in the url.
+
+If there are somehow multiple files with the same hash, returns the first one.
+
+Ex: `localhost:42069/file_by_hash/lkjlkjalijfljsdll9823`
 
 ### Output
 JSON object in the form:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Currently uses port `42069` by default, but will use the port specified in the c
 * POST - /add_file
 * PUT - /keep_alive
 * DELETE - /deregister_file
+* UPDATE - /tracker_sync
+* POST - /new_tracker
 
 ## GET - /file_list
 Gets the list of files that the tracker knows about.
@@ -98,7 +100,7 @@ JSON object in the form:
     "file_hash": "<hash of the full file>",    #string (sha256 hash)
     "peers": [
         {
-            "ip": "<peer's ip>" #string 
+            "ip": "<peer's ip>" #string
         },
         ...
     ],
@@ -141,7 +143,7 @@ JSON object in the form:
     "file_hash": "<hash of the full file>",    #string (sha256 hash)
     "peers": [
         {
-            "ip": "<peer's ip>" #string 
+            "ip": "<peer's ip>" #string
         },
         ...
     ],
@@ -199,7 +201,7 @@ JSON object in the form:
 
 ## POST - /add_file
 Adds a file to the tracker's list.
-Requires the hash of the file and all its chunks.
+Requires the peer guid, the hash of the file, all its chunks, and a sequence number.
 If a file with a matching hash already exists, adds the peer as a host for that file.
 Peer must provide their guid when adding a file.
 If the peer does not already have a guid, they can provide `null` and will be given a guid in the response.
@@ -222,7 +224,8 @@ JSON object in the form:
         },
         ...
     ],
-    "guid": "<client's guid>"/null   #string or null
+    "guid": "<client's guid>"/null,   #string or null
+    "sequence": <sequence number>   #integer
 }
 ```
 
@@ -293,7 +296,8 @@ JSON object in the form:
 ```python
 {
     "file_id": <files id in the tracker db>,   #integer
-    "guid": "<client's guid>"   #string
+    "guid": "<client's guid>",   #string
+    "sequence": <sequence number>   #integer
 }
 ```
 
@@ -301,9 +305,75 @@ JSON object in the form:
 JSON object in the form:
 ```python
 {
-    "success": true #boolean
+    "success": true   #boolean
 }
 ```
+
+### On Error
+JSON object in the form:
+```python
+{
+    "success": false,   #boolean
+    "error": "<error reason>"   #string
+}
+```
+
+## UPDATE - /tracker_sync
+Send/receive an information update to/from another tracker.
+If the tracker has seen the event already, it ignores it. If the tracker has not seen the
+event, it applies it to its own database and broadcasts it to other trackers.
+
+### Input
+JSON object in the form:
+```python
+{
+    "type": "add_file|keep_alive|deregister_file|new_tracker",   #string
+    "data": { ... },   #dictionary
+}
+```
+
+### Output
+JSON object in the form:
+```python
+{
+    "success": true   #boolean
+}
+```
+
+### On Error
+JSON object in the form:
+```python
+{
+    "success": false,   #boolean
+    "error": "<error reason>"   #string
+}
+```
+
+### Output
+JSON object in the form:
+```python
+{
+    "success": true   #boolean
+}
+```
+
+### On Error
+JSON object in the form:
+```python
+{
+    "success": false,   #boolean
+    "error": "<error reason>"   #string
+}
+```
+
+## POST - /new_tracker
+Register as a new tracker, getting a full database update.
+
+### Input
+No input is necessary for this endpoint.
+
+### Output
+TBD
 
 ### On Error
 JSON object in the form:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ JSON object in the form:
         {
             "id": <file id>,    #integer
             "name": "<file's name>",   #string
-            "hash": "<full file hash>" #base64 string
+            "hash": "<full file hash>", #base64 string
+            "peer_count": <number of recently keepalived peers> #integer
         },
         ...
     ]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Currently uses port `42069` by default, but will use the port specified in the c
 * POST - /add_file
 * PUT - /keep_alive
 * DELETE - /deregister_file
+* DELETE - /deregister_file_by_hash
 * UPDATE - /tracker_sync
 * POST - /new_tracker
 
@@ -68,7 +69,7 @@ JSON object in the form:
             "id": <file id>,    #integer
             "name": "<file's name>",   #string
             "hash": "<full file hash>", #base64 string
-            "peer_count": <number of recently keepalived peers> #integer
+            "active_peers": <number of recently keepalived peers> #integer
         },
         ...
     ]
@@ -226,7 +227,7 @@ JSON object in the form:
         ...
     ],
     "guid": "<client's guid>"/null,   #string or null
-    "sequence": <sequence number>   #integer
+    "seq_number": <clients current sequence number/sequence number of this message> #integer
 }
 ```
 
@@ -236,7 +237,7 @@ JSON object in the form:
 {
     "success": true,    #boolean
     "file_id": <the existing id if the tracker already has it, or the new one if it didnt>,   #integer
-    "guid": "<echoed guid if you had one already, otherwise your newly assigned one"    #string
+    "guid": "<echoed guid if you had one already, otherwise your newly assigned one>"    #string
 }
 ```
 
@@ -298,7 +299,7 @@ JSON object in the form:
 {
     "file_id": <files id in the tracker db>,   #integer
     "guid": "<client's guid>",   #string
-    "sequence": <sequence number>   #integer
+    "seq_number": <clients current sequence number/sequence number of this message> #integer
 }
 ```
 

--- a/api/models.py
+++ b/api/models.py
@@ -309,13 +309,22 @@ def add_file(add_file_data, peer_ip):
                     parent_file=new_file,
                 )
 
-        # TODO: if the file does exist, check that the submitted chunks match the existing chunks
+            # add relationship for the file and client
+            Hosts().create(
+                hosted_file=new_file,
+                hosting_peer=peer,
+            )
+        else:
+            # TODO: if the file does exist, check that the submitted chunks match the existing chunks
+            # add relationship for the file and client (if a relationship does not already exist)
+            # else error
+            _, host_created = Hosts().get_or_create(
+                hosted_file=new_file,
+                hosting_peer=peer,
+            )
 
-        # add relationship for the file and client (if a relationship does not already exist)
-        Hosts().get_or_create(
-            hosted_file=new_file,
-            hosting_peer=peer,
-        )
+            if(not host_created):
+                raise Exception("Peer with guid {} (you) is already hosting this file".format(add_file_data["guid"]))
 
         add_file_response["file_id"] = new_file.id
         add_file_response["guid"] = peer.uuid

--- a/api/routes.py
+++ b/api/routes.py
@@ -281,7 +281,6 @@ def keep_alive():
 
 # removes you as a host for this file
 # takes a json req with the client's guid and the file id as args
-# TODO: consider replacing the file id with a hash to make it tracker independent
 # --- INPUT ---
 # Expects JSON blob in the form:
 '''
@@ -334,3 +333,59 @@ def deregister_file():
         }
 
     return jsonify(deregister_file_response)
+
+
+# removes you as a host for this file
+# takes a json req with the client's guid and the file's full hash as args
+# --- INPUT ---
+# Expects JSON blob in the form:
+'''
+{
+    "file_hash": <file's full hash>,
+    "guid": "<client's guid>",
+    "seq_number": <client's current sequence number/sequence number of this message>
+}
+'''
+# --- OUTPUT ---
+# Returns a JSON blob in the form:
+'''
+{
+    "success": true
+}
+'''
+# --- ON ERROR ---
+# Returns a JSON blob in the form:
+'''
+{
+    "success": false,
+    "error": "<error reason>"
+}
+'''
+@app.route('/deregister_file_by_hash', methods=['DELETE'])
+def deregister_file_by_hash():
+    success = True
+
+    request_data = request.get_json(silent=True)
+    requester_ip = request.remote_addr
+
+    if(request_data is None):
+        error = "Request is not JSON"
+        success = False
+    else:
+        try:
+            validate(request_data, schemas.DEREGISTER_FILE_BY_HASH_SCHEMA)
+            deregister_file_by_hash_response = models.deregister_file_by_hash(request_data, requester_ip)
+        except ValidationError as e:
+            error = str(e)
+            success = False
+        except Exception as e:
+            error = str(e)
+            success = False
+
+    if(not success):
+        deregister_file_by_hash_response = {
+            "success": success,
+            "error": error,
+        }
+
+    return jsonify(deregister_file_by_hash_response)

--- a/api/routes.py
+++ b/api/routes.py
@@ -265,6 +265,7 @@ def deregister_file():
     success = True
 
     request_data = request.get_json(silent=True)
+    requester_ip = request.remote_addr
 
     if(request_data is None):
         error = "Request is not JSON"
@@ -272,7 +273,7 @@ def deregister_file():
     else:
         try:
             validate(request_data, schemas.DEREGISTER_FILE_SCHEMA)
-            deregister_file_response = models.deregister_file(request_data)
+            deregister_file_response = models.deregister_file(request_data, requester_ip)
         except ValidationError as e:
             error = str(e)
             success = False

--- a/api/routes.py
+++ b/api/routes.py
@@ -15,7 +15,7 @@ from jsonschema import validate, ValidationError
             "id": <file id>,
             "name": "<file's name>",
             "hash": "<full file hash>",
-            "peer_count": <number of recently keepalived peer>
+            "active_peers": <number of recently keepalived peer>
         },
         ...
     ]
@@ -173,7 +173,8 @@ def get_tracker_list():
         },
         ...
     ],
-    "guid": "<client's guid>"
+    "guid": "<client's guid>",
+    "seq_number": <client's current sequence number/sequence number of this message>
 }
 '''
 # --- OUTPUT ---
@@ -286,7 +287,8 @@ def keep_alive():
 '''
 {
     "file_id": <file's id in the tracker db>,
-    "guid": "<client's guid>"
+    "guid": "<client's guid>",
+    "seq_number": <client's current sequence number/sequence number of this message>
 }
 '''
 # --- OUTPUT ---

--- a/api/routes.py
+++ b/api/routes.py
@@ -40,7 +40,7 @@ def get_file_list():
 # TODO: consider replacing the id with the file's hash or to a json blob input to make it tracker independent
 # TODO: consider giving the chunk an id as well to make the chunk order clear
 # TODO: consider associating peers for each chunk
-# Gets the list of files the tracker knows about
+# Gets the information about a specific file id
 # --- INPUT ---
 # The file's id (as known by the tracker) via the url
 # --- OUTPUT ---
@@ -79,6 +79,49 @@ def get_file(file_id):
     get_file_response = models.get_file(file_id)
 
     return jsonify(get_file_response)
+
+
+# TODO: consider giving the chunk an id as well to make the chunk order clear
+# TODO: consider associating peers for each chunk
+# Gets the information about a specific file hash
+# --- INPUT ---
+# The file's id (as known by the tracker) via the url
+# --- OUTPUT ---
+# Returns a JSON blob of the form:
+'''
+{
+    "success": true,
+    "name": "<file name>",
+    "file_hash": "<hash of the full file>",
+    "peers": [
+        {"ip": "<peer's ip>"},
+        ...
+    ],
+    "chunks": [
+        {
+            "id": <chunk id for sequencing>,
+            "name": "<chunk filename>",
+            "hash": "<hash of chunk>"
+        },
+        ...
+    ]
+}
+'''
+# --- ON ERROR ---
+# Returns a JSON blob in the form:
+'''
+{
+    "success" : false,
+    "error" : "<error reason>",
+}
+'''
+@app.route('/file_by_hash/<file_full_hash>', methods=['GET'])
+def get_file_by_hash(file_full_hash):
+    # pull the file metadata from the db (name, list of peers, list of chunks, etc)
+
+    get_file_by_hash_response = models.get_file_by_hash(file_full_hash)
+
+    return jsonify(get_file_by_hash_response)
 
 
 # Gets the list of other trackers the tracker knows about

--- a/api/routes.py
+++ b/api/routes.py
@@ -14,7 +14,8 @@ from jsonschema import validate, ValidationError
         {
             "id": <file id>,
             "name": "<file's name>",
-            "hash": "<full file hash>"
+            "hash": "<full file hash>",
+            "peer_count": <number of recently keepalived peer>
         },
         ...
     ]

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -84,3 +84,25 @@ DEREGISTER_FILE_SCHEMA = {
     },
     "required": ["file_id", "guid", "seq_number"],
 }
+
+
+# --- DEREGISTER_FILE_BY_HASH SCHEMA ---
+# JSON schema for /deregister_file_by_hash endpoint inputs
+# Example:
+'''
+{
+    "file_hash" : <full hash of the file>,
+    "guid" : "<client's guid>",
+    "seq_number": <client's current sequence number/sequence number of this message>
+}
+'''
+DEREGISTER_FILE_BY_HASH_SCHEMA = {
+    "type": "object",
+    "maxProperties": 3,
+    "properties": {
+        "file_hash": {"type": "string"},
+        "guid": {"type": "string"},
+        "seq_number": {"type": "integer"},
+    },
+    "required": ["file_hash", "guid", "seq_number"],
+}

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -14,12 +14,13 @@
         },
         ...
     ],
-    "guid" : "<client's guid>"
+    "guid" : "<client's guid>",
+    "seq_number": <client's current sequence number/sequence number of this message>
 }
 '''
 ADD_FILE_SCHEMA = {
     "type": "object",
-    "maxProperties": 4,
+    "maxProperties": 5,
     "properties": {
         "name": {"type": "string"},
         "full_hash": {"type": "string"},
@@ -39,8 +40,9 @@ ADD_FILE_SCHEMA = {
             },
         },
         "guid": {"type": ["string", "null"]},
+        "seq_number": {"type": "integer"},
     },
-    "required": ["name", "full_hash", "chunks", "guid"],
+    "required": ["name", "full_hash", "chunks", "guid", "seq_number"],
 }
 
 
@@ -68,15 +70,17 @@ KEEP_ALIVE_SCHEMA = {
 '''
 {
     "file_id" : <file's id in the tracker db>,
-    "guid" : "<client's guid>"
+    "guid" : "<client's guid>",
+    "seq_number": <client's current sequence number/sequence number of this message>
 }
 '''
 DEREGISTER_FILE_SCHEMA = {
     "type": "object",
-    "maxProperties": 2,
+    "maxProperties": 3,
     "properties": {
         "file_id": {"type": "integer"},
         "guid": {"type": "string"},
+        "seq_number": {"type": "integer"},
     },
-    "required": ["file_id", "guid"],
+    "required": ["file_id", "guid", "seq_number"],
 }


### PR DESCRIPTION
Short overview:
- Prevent multiple of the same guid from adding the same file
- Validate chunks in /add_file when a new peer adds a file that already exists on the tracker
- Add support and validation for sequence numbers in /add_file, /deregister_file, and /deregister_file_by_hash
-  Add /file_by_hash and /deregister_file_by_hash endpoints
- Implement keepalive timeout support (default 5 minutes)
- Update IP/keepalive timestamp when peer uses /add_file, /deregister_file, or /deregister_file_by_hash
- Add active_peers count that counts recently keepalived peers to /file_list files