### PR TITLE
/peer_status endpoint and keep_alive sequence number

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,4 +21,4 @@ jsonschema = "*"
 toml = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "642ae9f7d628e4b1ce155bb7b40779d7c70d4e2a0b9ff0982cc0ca6d1d73373e"
+            "sha256": "43fc7c1640a3ec0aff91718858eb1d8e1afff37a818da849c6b635862c13f53e"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3"
         },
         "sources": [
             {
@@ -95,10 +95,10 @@
         },
         "peewee": {
             "hashes": [
-                "sha256:074331625cf4335a27af3a8f644eabe2858cd3fc91fa95a7f18db16bd640f7cc"
+                "sha256:603337153536b85c3c5b5e84df4ae0f9cbaff09163a3739451d167e0ad3fe1f7"
             ],
             "index": "pypi",
-            "version": "==3.9.2"
+            "version": "==3.9.3"
         },
         "pyrsistent": {
             "hashes": [
@@ -123,10 +123,10 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
-                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+                "sha256:96da23fa8ccecbc3ae832a83df5c722c11547d021637faacb0bec4dd2f4666c8",
+                "sha256:ca5c2dcd367d6c0df87185b9082929d255358f5391923269335782b213d52655"
             ],
-            "version": "==0.14.1"
+            "version": "==0.15.1"
         }
     },
     "develop": {

--- a/README.md
+++ b/README.md
@@ -263,7 +263,8 @@ Ex: `localhost:42069/keep_alive`
 JSON object in the form:
 ```python
 {
-    "guid": "<client's guid>"   #string
+    "guid": "<client's guid>",   #string
+    "ka_seq_number": <keepalive sequence number>    #integer
 }
 ```
 
@@ -353,6 +354,32 @@ JSON object in the form:
 {
     "success": false,   #boolean
     "error": "<error reason>"   #string
+}
+```
+
+## GET - /peer_status/<peer_guid>
+Gets the information about a specific peer this includes what files it is hosting, its expected sequence number, and its expected keep alive number.
+
+### Input
+GET request to the endpoint url, containing the peer's guid in the url.
+
+Ex: `localhost:42069/peer_guid/d16f97be-0325-4fe8-98f5-b1fc128ae0d6`
+
+### Output
+JSON object in the form:
+```python
+{
+    "success": true,
+    "files": [
+        {
+            "id": <file's id according to the tracker>,
+            "name": "<file's name>",
+            "hash": "<full file hash>"
+        },
+        ...
+    ],
+    "expected_seq_number": <expected normal sequence number>,
+    "ka_expected_seq_number": <expected keepalive sequence number>
 }
 ```
 

--- a/api/models.py
+++ b/api/models.py
@@ -429,7 +429,7 @@ def keep_alive(keep_alive_data, peer_ip):
         if(peer.ip != peer_ip):
             peer.ip = peer_ip
         peer.keep_alive_timestamp = datetime.datetime.now()
-        peer.expected_seq_number += 1
+        peer.ka_expected_seq_number += 1
         peer.save()
     except Peer.DoesNotExist:
         error = "Peer with guid {} does not exist".format(keep_alive_data["guid"])
@@ -464,7 +464,7 @@ def deregister_file(deregister_file_data, peer_ip):
         peer.save()
 
         if(peer.expected_seq_number != deregister_file_data["seq_number"]):
-            raise Exception("Tracker is expecting sequence number {} (sequence number {} was sent"
+            raise Exception("Tracker is expecting sequence number {} (sequence number {} was sent)"
                             .format(peer.expected_seq_number, deregister_file_data["seq_number"]))
 
         # checks if specified peer is hosting specified file, if so deletes the record
@@ -589,7 +589,7 @@ def get_peer_status(peer_guid):
 
         if(peer_file_list_query.exists()):
             for file in peer_file_list_query:
-                peer_status_response["files"].append(file.to_dict())
+                peer_status_response["files"].append(file.to_dict_simple())
 
         peer_status_response["expected_seq_number"] = selected_peer.expected_seq_number
         peer_status_response["ka_expected_seq_number"] = selected_peer.ka_expected_seq_number

--- a/api/routes.py
+++ b/api/routes.py
@@ -231,7 +231,8 @@ def add_file():
 # Expects JSON blob in the form:
 '''
 {
-    "guid": "<client's guid>"
+    "guid": "<client's guid>",
+    "ka_seq_number": <keepalive sequence number>    #integer
 }
 '''
 # --- OUTPUT ---
@@ -389,3 +390,42 @@ def deregister_file_by_hash():
         }
 
     return jsonify(deregister_file_by_hash_response)
+
+
+# Gets the information about a specific peer
+# this includes what files it is hosting, its expected sequence number,
+# and its expected keep alive number
+# --- INPUT ---
+# The peer's guid via the url
+# --- OUTPUT ---
+# Returns a JSON blob of the form:
+'''
+{
+    "success": true,
+    "files": [
+        {
+            "id": <file's id according to the tracker>,
+            "name": "<file's name>",
+            "hash": "<full file hash>"
+        },
+        ...
+    ],
+    "expected_seq_number": <expected normal sequence number>,
+    "ka_expected_seq_number": <expected keepalive sequence number>
+}
+'''
+# --- ON ERROR ---
+# Returns a JSON blob in the form:
+'''
+{
+    "success" : false,
+    "error" : "<error reason>",
+}
+'''
+@app.route('/peer_status/<peer_guid>', methods=['GET'])
+def peer_status(peer_guid):
+    # pull the peer data from the db (hosted files, seq numbers)
+
+    peer_status_response = models.get_peer_status(peer_guid)
+
+    return jsonify(peer_status_response)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -56,11 +56,12 @@ ADD_FILE_SCHEMA = {
 '''
 KEEP_ALIVE_SCHEMA = {
     "type": "object",
-    "maxProperties": 1,
+    "maxProperties": 2,
     "properties": {
         "guid": {"type": "string"},
+        "ka_seq_number": {"type": "integer"},
     },
-    "required": ["guid"],
+    "required": ["guid", "ka_seq_number"],
 }
 
 


### PR DESCRIPTION
Overview:

- Added /peer_status endpoint that returns the peer's expected sequence number, keep_alive sequence number, and hosted files (according to the tracker)
- Added keep_alive sequence number. /keep_alive now uses a separate sequence number from /deregister_file(_by_hash) and /add_file for simplifying concurrency reasons